### PR TITLE
Change title as link to enable open in new tab

### DIFF
--- a/webportal/src/app/market_list/components/item_card.jsx
+++ b/webportal/src/app/market_list/components/item_card.jsx
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
-import { Text, Stack } from 'office-ui-fabric-react';
+import { Text, Stack, Link } from 'office-ui-fabric-react';
+import { FontClassNames } from '@uifabric/styling';
 import styled from 'styled-components';
 
 import Card from 'App/components/card';
@@ -47,12 +48,12 @@ const ItemCard = props => {
           {item.type === 'old' && <TemplateIcon />}
         </Stack.Item>
         <Stack gap='m' styles={{ root: [{ width: '70%' }] }}>
-          <Text
-            variant={'xLarge'}
-            styles={{ root: { overflowWrap: 'anywhere' } }}
+          <Link
+            className={FontClassNames.xLarge}
+            href={`/plugin.html?index=0#/market_detail?itemId=${item.id}`}
           >
             {item.name}
-          </Text>
+          </Link>
           <Text variant={'small'}>
             {item.author} published {populateCreatedTime()}
           </Text>


### PR DESCRIPTION
1. Change title from <Text> to <Link>. When user right click title, an option of 'open in new tab' could be selected.

![image](https://user-images.githubusercontent.com/8444268/91704812-a6976d00-ebae-11ea-8990-2b66a66790fa.png)
