### PR TITLE
Add searchbox in side bar

### DIFF
--- a/webportal/src/app/market_list/components/item_list.jsx
+++ b/webportal/src/app/market_list/components/item_list.jsx
@@ -19,17 +19,23 @@ const GridWrapper = styled.div`
 `;
 
 const ItemList = props => {
-  const { type } = props;
+  const { type, keyword } = props;
   const [itemList, setItemList] = useState([]);
   const [loading, setLoading] = useState(true);
   useEffect(() => {
     async function fetchData() {
-      const items = await listItems(type);
-      setItemList(items);
-      setLoading(false);
+      try {
+        const items = await listItems(type, keyword);
+        setItemList(items);
+        setLoading(false);
+      } catch (e) {
+        alert(e.message);
+        setItemList([]);
+        setLoading(false);
+      }
     }
     fetchData();
-  }, [type]);
+  }, [type, keyword]);
 
   return (
     <div>
@@ -57,6 +63,7 @@ const ItemList = props => {
 
 ItemList.propTypes = {
   type: PropTypes.string,
+  keyword: PropTypes.string,
 };
 
 export default ItemList;

--- a/webportal/src/app/market_list/components/side_bar.jsx
+++ b/webportal/src/app/market_list/components/side_bar.jsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 import React, { useContext } from 'react';
-import { getTheme, Stack, Text } from 'office-ui-fabric-react';
+import { getTheme, Stack, Text, SearchBox } from 'office-ui-fabric-react';
 import PropTypes from 'prop-types';
 import FilterItem from './filter_item';
 import Context from 'App/context';
@@ -27,6 +27,7 @@ const SideBar = props => {
       styles={{ root: { width: 200, padding: `${spacing.s1}` } }}
       gap={spacing.l1}
     >
+      <SearchBox />
       <Text variant={'large'}>Types</Text>
       <Stack>
         <FilterItem

--- a/webportal/src/app/market_list/components/side_bar.jsx
+++ b/webportal/src/app/market_list/components/side_bar.jsx
@@ -1,25 +1,55 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { getTheme, Stack, Text, SearchBox } from 'office-ui-fabric-react';
-import PropTypes from 'prop-types';
-import FilterItem from './filter_item';
+import queryString from 'query-string';
+import { isNil } from 'lodash';
+import TypeFilter from './type_filter';
 import Context from 'App/context';
 import { TYPE_ENUM } from 'App/utils/constants';
 
-const SideBar = props => {
-  const { type } = props;
+const SideBar = () => {
+  const [type, setType] = useState(null);
+  const [keyword, setKeyword] = useState();
   const { spacing } = getTheme();
   const { history } = useContext(Context);
 
-  const changeFilter = filter => {
-    return selected => {
-      if (selected) {
-        history.push('/');
+  const getQueryString = (type, keyword) => {
+    let qs = '';
+    if (isNil(keyword) || keyword === '') {
+      if (isNil(type)) {
+        qs = '';
       } else {
-        history.push(`/?type=${filter}`);
+        qs = queryString.stringify({ type });
+      }
+    } else {
+      if (isNil(type)) {
+        qs = queryString.stringify({ keyword });
+      } else {
+        qs = queryString.stringify({ type, keyword });
+      }
+    }
+    return qs;
+  };
+
+  const changeType = newType => {
+    return () => {
+      if (type === newType) {
+        setType(null);
+        const qs = getQueryString(null, keyword);
+        history.push(`/?${qs}`);
+      } else {
+        setType(newType);
+        const qs = getQueryString(newType, keyword);
+        history.push(`/?${qs}`);
       }
     };
+  };
+
+  const searchKeyword = newKeyword => {
+    setKeyword(newKeyword);
+    const qs = getQueryString(type, newKeyword);
+    history.push(`/?${qs}`);
   };
 
   return (
@@ -27,36 +57,32 @@ const SideBar = props => {
       styles={{ root: { width: 200, padding: `${spacing.s1}` } }}
       gap={spacing.l1}
     >
-      <SearchBox />
+      <SearchBox onSearch={searchKeyword} />
       <Text variant={'large'}>Types</Text>
       <Stack>
-        <FilterItem
+        <TypeFilter
           text='All'
           selected={type === TYPE_ENUM.ALL}
-          onChange={changeFilter(TYPE_ENUM.ALL)}
+          onClick={changeType(TYPE_ENUM.ALL)}
         />
-        <FilterItem
+        <TypeFilter
           text='Data Template'
           selected={type === TYPE_ENUM.DATA_TEMPLATE}
-          onChange={changeFilter(TYPE_ENUM.DATA_TEMPLATE)}
+          onClick={changeType(TYPE_ENUM.DATA_TEMPLATE)}
         />
-        <FilterItem
+        <TypeFilter
           text='Job Template'
           selected={type === TYPE_ENUM.JOB_TEMPLATE}
-          onChange={changeFilter(TYPE_ENUM.JOB_TEMPLATE)}
+          onClick={changeType(TYPE_ENUM.JOB_TEMPLATE)}
         />
-        <FilterItem
+        <TypeFilter
           text='Old Example'
           selected={type === TYPE_ENUM.OLD_TEMPLATE}
-          onChange={changeFilter(TYPE_ENUM.OLD_TEMPLATE)}
+          onClick={changeType(TYPE_ENUM.OLD_TEMPLATE)}
         />
       </Stack>
     </Stack>
   );
-};
-
-SideBar.propTypes = {
-  type: PropTypes.string,
 };
 
 export default SideBar;

--- a/webportal/src/app/market_list/components/type_filter.jsx
+++ b/webportal/src/app/market_list/components/type_filter.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { getTheme, Text, Icon } from 'office-ui-fabric-react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import { isNil } from 'lodash';
 
 const { spacing, palette } = getTheme();
 
@@ -26,19 +25,10 @@ const Wrapper = styled.div`
 `;
 
 const FilterItem = props => {
-  const { text, selected, onChange } = props;
+  const { text, selected, onClick } = props;
 
   return (
-    <Wrapper
-      selected={selected}
-      onClick={
-        isNil(onChange)
-          ? null
-          : () => {
-              onChange(selected);
-            }
-      }
-    >
+    <Wrapper selected={selected} onClick={onClick}>
       <Text>{text}</Text>
       {selected && <Icon iconName='Cancel' />}
     </Wrapper>
@@ -48,7 +38,7 @@ const FilterItem = props => {
 FilterItem.propTypes = {
   text: PropTypes.string.isRequired,
   selected: PropTypes.bool,
-  onChange: PropTypes.func,
+  onClick: PropTypes.func,
 };
 
 export default FilterItem;

--- a/webportal/src/app/market_list/market_list.jsx
+++ b/webportal/src/app/market_list/market_list.jsx
@@ -47,13 +47,7 @@ const MarketList = props => {
         </Stack>
         <Stack horizontal gap={spacing.l1}>
           <StackItem>
-            <SideBar
-              type={
-                isNil(qs.parse(routeProps.location.search).type)
-                  ? TYPE_ENUM.ALL
-                  : qs.parse(routeProps.location.search).type
-              }
-            />
+            <SideBar />
           </StackItem>
           <StackItem grow={1}>
             <ItemList
@@ -62,6 +56,7 @@ const MarketList = props => {
                   ? TYPE_ENUM.ALL
                   : qs.parse(routeProps.location.search).type
               }
+              keyword={qs.parse(routeProps.location.search).keyword}
             />
           </StackItem>
         </Stack>

--- a/webportal/src/app/utils/marketplace_api.js
+++ b/webportal/src/app/utils/marketplace_api.js
@@ -34,8 +34,16 @@ export async function getConnectionString(
   }
 }
 
-export async function listItems(type) {
-  const url = `${MARKETPLACE_API_URL}/items${type ? '?type=' + type : ''}`;
+export async function listItems(type, keyword) {
+  const queryOptions = {};
+  if (type) {
+    queryOptions.type = type;
+  }
+  if (keyword) {
+    queryOptions.keyword = keyword;
+  }
+  const queryStr = queryString.stringify(queryOptions);
+  const url = `${MARKETPLACE_API_URL}/items?${queryStr}`;
   const res = await fetch(url);
   if (res.ok) {
     const items = await res.json();


### PR DESCRIPTION
### Implementation:
- type some keywords and press enter to trigger onSearch event
- set two states in SideBar: type and keyword, when the states are changes the url will changed to`/?type=<type>&keyword=<keyword>`
- ItemList will fetch items from api based on url, i.e. send items request with query `?type=<type>&keyword=<keyword>`
- In rest server, uses sequelize [Op.substring] operation to query sql database

### Demo:
![image](https://user-images.githubusercontent.com/8444268/101731667-ec8d9680-3af6-11eb-8877-b12f1867fc21.png)

### Test Cases:
#160 

### Known Issues:
- ~search keyword is case sensitive because [Op.substring] is case sensitive~

### Left work
- show results number and keyword in itemlist
