### PR TITLE
Show template name instead of the ID in create completed page

### DIFF
--- a/webportal/src/app/create_item/components/create_completed.jsx
+++ b/webportal/src/app/create_item/components/create_completed.jsx
@@ -50,7 +50,7 @@ const CreateCompleted = props => {
       </Stack>
       <Text>
         You can find your template{' '}
-        <Link onClick={viewItem}>{state.itemId}</Link> in the{' '}
+        <Link onClick={viewItem}>{state.itemObject.name}</Link> in the{' '}
         <Link onClick={viewList}>Marketplace list</Link>
       </Text>
     </Stack>


### PR DESCRIPTION
Fix #170 