### PR TITLE
Fix admin can't delete other author's item

### DIFF
--- a/webportal/src/app/utils/marketplace_api.js
+++ b/webportal/src/app/utils/marketplace_api.js
@@ -137,9 +137,8 @@ export async function createItem(marketItem) {
   }
 }
 
-export async function deleteItem(itemId, user) {
+export async function deleteItem(itemId) {
   const url = `${MARKETPLACE_API_URL}/items/${itemId}`;
-  const item = await getItem(itemId);
 
   const token = cookies.get('token');
 

--- a/webportal/src/app/utils/marketplace_api.js
+++ b/webportal/src/app/utils/marketplace_api.js
@@ -141,10 +141,6 @@ export async function deleteItem(itemId, user) {
   const url = `${MARKETPLACE_API_URL}/items/${itemId}`;
   const item = await getItem(itemId);
 
-  if (item.author !== user.user && !user.admin) {
-    throw new Error('permission denied');
-  }
-
   const token = cookies.get('token');
 
   const res = await fetch(url, {


### PR DESCRIPTION
Login OpenPAI with a admin user, delete a marketplace item, got no permission.

![image](https://user-images.githubusercontent.com/17357108/109249073-f71c1a00-7821-11eb-8e9d-cf15177cfe0c.png)

![image](https://user-images.githubusercontent.com/17357108/109249113-069b6300-7822-11eb-845c-9cb2f3b98cf8.png)

The UI only show delete button for admin/author, and the API will also check the permission. So I just remove the wrong permission check in this PR.

