### PR TITLE
[Bug fix] Fix the share option default selected and update may not effected

### DIFF
--- a/webportal/src/app/market_detail/components/edit_popup.jsx
+++ b/webportal/src/app/market_detail/components/edit_popup.jsx
@@ -107,12 +107,15 @@ export const EditPopup = props => {
             text='Submit'
             onClick={() => {
               marketItemDispatch({ type: 'updateItem', value: editTempItem });
+              // Dispatch is handled asynchronously and API does not provide any way of executing a piece of code after the dispatch has been executed.
+              // The marketItem here may be the old one, so we merge the item manually.
+              const newItem = { ...marketItem, ...editTempItem };
               updateItem(
                 {
-                  ...marketItem,
-                  protocol: JSON.stringify(marketItem.protocol),
+                  ...newItem,
+                  protocol: JSON.stringify(newItem.protocol),
                 },
-                marketItem.itemId,
+                newItem.itemId,
               ).then(() => {
                 hideModal();
               });

--- a/webportal/src/app/market_detail/components/share_options.jsx
+++ b/webportal/src/app/market_detail/components/share_options.jsx
@@ -13,6 +13,22 @@ import {
 } from 'office-ui-fabric-react';
 import { listGroups } from 'App/utils/pai_api';
 
+const optionTypes = {
+  PUBLIC: 'public',
+  PRIVATE: 'private',
+  PROTECTED: 'protected',
+};
+
+function getOptionTypes(item) {
+  if (item.isPrivate) {
+    return optionTypes.PRIVATE;
+  } else if (item.isPublic) {
+    return optionTypes.PUBLIC;
+  } else {
+    return optionTypes.PROTECTED;
+  }
+}
+
 export const ShareOptions = props => {
   const { marketItem, dispatch, api } = props;
   var groupList = marketItem.groupList;
@@ -34,10 +50,10 @@ export const ShareOptions = props => {
   }, []);
 
   const options = [
-    { key: 'Private', text: 'Private' },
-    { key: 'Public', text: 'Public' },
+    { key: optionTypes.PRIVATE, text: 'Private' },
+    { key: optionTypes.PUBLIC, text: 'Public' },
     {
-      key: 'Protected',
+      key: optionTypes.PROTECTED,
       text: 'Protected',
       onRenderField: (props, render) => {
         return (
@@ -74,11 +90,11 @@ export const ShareOptions = props => {
   ];
 
   const onChoiceChange = (_, option) => {
-    if (option.key === 'Public') {
+    if (option.key === optionTypes.PUBLIC) {
       dispatch({ type: 'setPublic' });
-    } else if (option.key === 'Private') {
+    } else if (option.key === optionTypes.PRIVATE) {
       dispatch({ type: 'setPrivate' });
-    } else {
+    } else if (option.key === optionTypes.PROTECTED) {
       dispatch({ type: 'setGroupList', value: groupList });
     }
   };
@@ -97,7 +113,7 @@ export const ShareOptions = props => {
         Share Option
       </Label>
       <ChoiceGroup
-        defaultSelectedKey='Private'
+        defaultSelectedKey={getOptionTypes(marketItem)}
         options={options}
         onChange={onChoiceChange}
       />


### PR DESCRIPTION
How to reproduce:
1. click an item from marketplace item list
2. click `...` and select `edit`
3. the default share option always be `private` even it's a public item
4. change the share option and click submit (like private -> public)
5. the share option in the detail page will be change
6. click refresh or `F5` in the browser
7. the share option may roll back to the old one