### PR TITLE
Fix some private items are also public

### DIFF
--- a/rest_server/src/models/marketplace_item.js
+++ b/rest_server/src/models/marketplace_item.js
@@ -246,6 +246,10 @@ class MarketplaceItem {
 
   async create(itemReq) {
     const handler = modelSyncHandler(async itemReq => {
+      // Item's 3 different cases:
+      // 1. Share to all users (isPublic: true)
+      // 2. Private (isPrivate: true)
+      // 3. Share to some specific groups (isPublic: false & isPrivate: false)
       if (itemReq.isPrivate) {
         itemReq.isPublic = false;
         itemReq.groupList = [];

--- a/rest_server/src/models/marketplace_item.js
+++ b/rest_server/src/models/marketplace_item.js
@@ -24,7 +24,7 @@ class MarketplaceItem {
       isPublic: {
         type: DataTypes.BOOLEAN,
         allowNull: false,
-        defaultValue: true,
+        defaultValue: false,
       },
       isPrivate: {
         type: DataTypes.BOOLEAN,

--- a/rest_server/src/models/marketplace_item.js
+++ b/rest_server/src/models/marketplace_item.js
@@ -24,7 +24,7 @@ class MarketplaceItem {
       isPublic: {
         type: DataTypes.BOOLEAN,
         allowNull: false,
-        defaultValue: false,
+        defaultValue: true,
       },
       isPrivate: {
         type: DataTypes.BOOLEAN,
@@ -246,6 +246,14 @@ class MarketplaceItem {
 
   async create(itemReq) {
     const handler = modelSyncHandler(async itemReq => {
+      if (itemReq.isPrivate) {
+        itemReq.isPublic = false;
+        itemReq.groupList = [];
+      } else if (itemReq.isPublic) {
+        itemReq.isPrivate = false;
+        itemReq.groupList = [];
+      }
+
       const item = await this.orm.create(itemReq);
       return item.id;
     });


### PR DESCRIPTION
Post item with `isPrivate: true` and ignore `isPublic` field, will create an item with both private and public:

The request:
![image](https://user-images.githubusercontent.com/17357108/123784524-1cbd4b00-d90a-11eb-8d91-d0177ca8f670.png)

In marketplace item list:
![image](https://user-images.githubusercontent.com/17357108/123784589-2e9eee00-d90a-11eb-8721-c29bf0be3a4a.png)

This PR will fix them